### PR TITLE
`Bugfix`: Fix path parameter code generation

### DIFF
--- a/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
+++ b/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
@@ -386,7 +386,7 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
             } else if (useSignalValue && signalValueByParamName.containsKey(valueVar)) {
                 replacementVar = signalValueByParamName.get(valueVar);
             }
-            String replacement = "${" + replacementVar + "}";
+            String replacement = "{" + replacementVar + "}";
             matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(buffer);


### PR DESCRIPTION
### Motivation and Context

While testing the Angular 21 OpenAPI generator, i noticed that URLs containing path parameters are generated with a double $ (e.g. /admin/users/$${userId}).
This results in invalid URLs at runtime, since Angular/TypeScript template literals expect exactly one ${…} interpolation.

### Description

This PR fixes incorrect URL generation for path parameters in the Angular21Generator.

Previously, the generator reintroduced a template literal interpolation (${…}) even though the base generator already provided one, leading to an extra $ in the final output.