### PR TITLE
Harden Tutorial Groups generation

### DIFF
--- a/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
+++ b/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
@@ -193,6 +193,14 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
     }
 
     @Override
+    public String toModelImport(String name) {
+        if (importMapping.containsKey(name)) {
+            return importMapping.get(name);
+        }
+        return "../models/" + toModelFilename(removeModelPrefixSuffix(name));
+    }
+
+    @Override
     public String toApiName(String name) {
         return StringUtils.camelize(name) + "Api";
     }
@@ -307,8 +315,32 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
         operations.put("mutationOperations", mutationOperations);
         operations.put("hasGetOperations", !getOperations.isEmpty());
         operations.put("hasMutationOperations", !mutationOperations.isEmpty());
+        result.put("resourceImports", filterImports(result.getImports(), getOperations));
+        result.put("mutationImports", filterImports(result.getImports(), mutationOperations));
 
         return result;
+    }
+
+    private List<Map<String, String>> filterImports(List<Map<String, String>> imports, List<CodegenOperation> operations) {
+        if (imports == null || imports.isEmpty() || operations.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<String> usedImports = new HashSet<>();
+        for (CodegenOperation operation : operations) {
+            if (operation.imports != null) {
+                usedImports.addAll(operation.imports);
+            }
+        }
+
+        List<Map<String, String>> filteredImports = new ArrayList<>();
+        for (Map<String, String> importEntry : imports) {
+            String className = importEntry.get("classname");
+            if (usedImports.contains(className)) {
+                filteredImports.add(importEntry);
+            }
+        }
+        return filteredImports;
     }
 
     /**
@@ -401,6 +433,10 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
                     valueVar = templateVarByParamName.get(param.paramName);
                 }
                 String placeholder = "{" + param.baseName + "}";
+                String generatedPlaceholder = "{" + valueVar + "}";
+                if (!generatedPlaceholder.equals(placeholder)) {
+                    path = path.replace(generatedPlaceholder, "${" + valueVar + "}");
+                }
                 path = path.replace(placeholder, "${" + valueVar + "}");
             }
         }

--- a/src/main/resources/angular21/api-resource.mustache
+++ b/src/main/resources/angular21/api-resource.mustache
@@ -6,9 +6,9 @@
  */
 import { httpResource, HttpResourceRef } from '@angular/common/http';
 import { Signal } from '@angular/core';
-{{#imports}}
-import { {{classname}} } from '../models/{{classFilename}}';
-{{/imports}}
+{{#resourceImports}}
+import { {{classname}} } from '{{filename}}';
+{{/resourceImports}}
 
 const BASE_PATH = '{{contextPath}}';
 

--- a/src/main/resources/angular21/api-service.mustache
+++ b/src/main/resources/angular21/api-service.mustache
@@ -6,9 +6,9 @@
 import { HttpClient{{#operations.operation}}{{#hasFormParams}}, HttpHeaders{{/hasFormParams}}{{/operations.operation}} } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-{{#imports}}
-import { {{classname}} } from '../models/{{classFilename}}';
-{{/imports}}
+{{#mutationImports}}
+import { {{classname}} } from '{{filename}}';
+{{/mutationImports}}
 
 @Injectable({ providedIn: 'root' })
 export class {{classname}} {
@@ -61,19 +61,19 @@ export class {{classname}} {
 {{/isArray}}
         }
 {{/formParams}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url, formData);
+        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}{{^returnType}}<void>{{/returnType}}(url, formData);
 {{/hasFormParams}}
 {{^hasFormParams}}
 {{#bodyParam}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url, {{paramName}});
+        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}{{^returnType}}<void>{{/returnType}}(url, {{paramName}});
 {{/bodyParam}}
 {{^bodyParam}}
 {{#hasQueryParams}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url);
+        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}{{^returnType}}<void>{{/returnType}}(url);
 {{/hasQueryParams}}
 {{^hasQueryParams}}
 {{#vendorExtensions.x-is-mutation}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url{{#isBodyAllowed}}, null{{/isBodyAllowed}});
+        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}{{^returnType}}<void>{{/returnType}}(url{{#isBodyAllowed}}, null{{/isBodyAllowed}});
 {{/vendorExtensions.x-is-mutation}}
 {{/hasQueryParams}}
 {{/bodyParam}}

--- a/src/main/resources/angular21/model.mustache
+++ b/src/main/resources/angular21/model.mustache
@@ -2,7 +2,7 @@
 {{#models}}
 {{#model}}
 {{#tsImports}}
-import type { {{classname}} } from '{{filename}}';
+import type { {{classname}} } from './{{filename}}';
 {{/tsImports}}
 
 {{#description}}

--- a/src/test/java/de/tum/cit/aet/openapi/Angular21GeneratorTest.java
+++ b/src/test/java/de/tum/cit/aet/openapi/Angular21GeneratorTest.java
@@ -1,0 +1,80 @@
+package de.tum.cit.aet.openapi;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+class Angular21GeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void generatesTutorialGroupsResourcesAndMutationServices() throws IOException {
+        generateFixture("fixtures/tutorial-groups-openapi.yaml", tempDir);
+
+        Path tutorialGroupResources = tempDir.resolve("api/tutorial-group-resources.ts");
+        Path tutorialGroupApi = tempDir.resolve("api/tutorial-group-api.ts");
+        Path freePeriodResources = tempDir.resolve("api/tutorial-group-free-period-resources.ts");
+        Path freePeriodApi = tempDir.resolve("api/tutorial-group-free-period-api.ts");
+
+        assertTrue(Files.exists(tutorialGroupResources));
+        assertTrue(Files.exists(tutorialGroupApi));
+        assertTrue(Files.exists(freePeriodResources));
+        assertTrue(Files.exists(freePeriodApi));
+
+        String resources = Files.readString(tutorialGroupResources);
+        assertContains(resources, "import { TutorialGroupDetailData } from '../models/tutorial-group-detail-data';");
+        assertFalse(resources.contains("from '../models/tutorial-group'"));
+        assertFalse(resources.contains("CreateOrUpdateTutorialGroupRequest"));
+        assertContains(resources, "export function getTutorialGroupsResource(");
+        assertContains(resources, "courseId: Signal<number> | number");
+        assertContains(resources, "params?: Signal<GetTutorialGroupsParams>");
+        assertContains(resources, "searchParams.append('campus', String(value))");
+        assertContains(resources, "return `${BASE_PATH}/tutorialgroup/courses/${courseIdValue}/tutorial-groups${query ? `?${query}` : ''}`;");
+        assertFalse(resources.contains("createTutorialGroup"));
+
+        String api = Files.readString(tutorialGroupApi);
+        assertContains(api, "import { CreateOrUpdateTutorialGroupRequest } from '../models/create-or-update-tutorial-group-request';");
+        assertContains(api, "import { TutorialGroupDetailData } from '../models/tutorial-group-detail-data';");
+        assertFalse(api.contains("from '../models/tutorial-group'"));
+        assertContains(api, "export class TutorialGroupApi");
+        assertContains(api, "createTutorialGroup(courseId: number, createOrUpdateTutorialGroupRequest: CreateOrUpdateTutorialGroupRequest): Observable<TutorialGroupDetailData>");
+        assertContains(api, "return this.http.post<TutorialGroupDetailData>(url, createOrUpdateTutorialGroupRequest);");
+        assertContains(api, "return this.http.put<TutorialGroupDetailData>(url, createOrUpdateTutorialGroupRequest);");
+        assertContains(api, "return this.http.delete<void>(url");
+        assertFalse(api.contains("this.http.POST"));
+        assertFalse(api.contains("this.http.PUT"));
+        assertFalse(api.contains("getTutorialGroup("));
+
+        String model = Files.readString(tempDir.resolve("models/tutorial-group-detail-data.ts"));
+        assertContains(model, "readonly id: number;");
+        assertContains(model, "readonly title: string;");
+
+        String requestModel = Files.readString(tempDir.resolve("models/create-or-update-tutorial-group-request.ts"));
+        assertContains(requestModel, "title: string;");
+        assertFalse(requestModel.contains("readonly title"));
+    }
+
+    private static void generateFixture(String fixture, Path outputDir) {
+        String inputSpec = Path.of("src/test/resources").resolve(fixture).toAbsolutePath().toString();
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(Angular21Generator.GENERATOR_NAME)
+                .setInputSpec(inputSpec)
+                .setOutputDir(outputDir.toString());
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+    }
+
+    private static void assertContains(String actual, String expected) {
+        assertTrue(actual.contains(expected), () -> "Expected generated output to contain:\n" + expected + "\n\nActual output:\n" + actual);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/openapi/Angular21GeneratorTest.java
+++ b/src/test/java/de/tum/cit/aet/openapi/Angular21GeneratorTest.java
@@ -59,6 +59,10 @@ class Angular21GeneratorTest {
         assertContains(model, "readonly id: number;");
         assertContains(model, "readonly title: string;");
 
+        String configurationModel = Files.readString(tempDir.resolve("models/tutorial-group-configuration.ts"));
+        assertContains(configurationModel, "import type { TutorialGroupFreePeriod } from './tutorial-group-free-period';");
+        assertFalse(configurationModel.contains("from 'tutorial-group-free-period'"));
+
         String requestModel = Files.readString(tempDir.resolve("models/create-or-update-tutorial-group-request.ts"));
         assertContains(requestModel, "title: string;");
         assertFalse(requestModel.contains("readonly title"));

--- a/src/test/resources/fixtures/tutorial-groups-openapi.yaml
+++ b/src/test/resources/fixtures/tutorial-groups-openapi.yaml
@@ -1,0 +1,287 @@
+openapi: 3.1.1
+info:
+  title: Artemis Tutorial Groups API
+  version: 1.0.0
+servers:
+  - url: /api
+tags:
+  - name: tutorial-group
+    description: Tutorial group management
+  - name: tutorial-group-free-period
+    description: Tutorial group free period management
+paths:
+  /tutorialgroup/courses/{courseId}/tutorial-groups:
+    get:
+      tags:
+        - tutorial-group
+      operationId: getTutorialGroups
+      summary: Get tutorial groups for a course
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: registered
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: campus
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Tutorial groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TutorialGroupDetailData'
+    post:
+      tags:
+        - tutorial-group
+      operationId: createTutorialGroup
+      summary: Create a tutorial group
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrUpdateTutorialGroupRequest'
+      responses:
+        '200':
+          description: Created tutorial group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TutorialGroupDetailData'
+  /tutorialgroup/courses/{courseId}/tutorial-groups/{tutorialGroupId}:
+    get:
+      tags:
+        - tutorial-group
+      operationId: getTutorialGroup
+      summary: Get one tutorial group
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: tutorialGroupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Tutorial group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TutorialGroupDetailData'
+    put:
+      tags:
+        - tutorial-group
+      operationId: updateTutorialGroup
+      summary: Update a tutorial group
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: tutorialGroupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrUpdateTutorialGroupRequest'
+      responses:
+        '200':
+          description: Updated tutorial group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TutorialGroupDetailData'
+    delete:
+      tags:
+        - tutorial-group
+      operationId: deleteTutorialGroup
+      summary: Delete a tutorial group
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: tutorialGroupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: Deleted
+  /tutorialgroup/courses/{courseId}/tutorial-groups-configuration/{configurationId}/tutorial-free-periods/{freePeriodId}:
+    get:
+      tags:
+        - tutorial-group-free-period
+      operationId: getTutorialGroupFreePeriod
+      summary: Get one free period
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: configurationId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: freePeriodId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Free period
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TutorialGroupFreePeriod'
+    put:
+      tags:
+        - tutorial-group-free-period
+      operationId: updateTutorialGroupFreePeriod
+      summary: Update a free period
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: configurationId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: freePeriodId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TutorialGroupFreePeriodRequest'
+      responses:
+        '200':
+          description: Updated free period
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TutorialGroupFreePeriod'
+components:
+  schemas:
+    CreateOrUpdateTutorialGroupRequest:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+        additionalInformation:
+          type: string
+        capacity:
+          type: integer
+          format: int32
+        language:
+          type: string
+    TutorialGroupDetailData:
+      type: object
+      required:
+        - id
+        - title
+      properties:
+        id:
+          type: integer
+          format: int64
+        title:
+          type: string
+        campus:
+          type: string
+        capacity:
+          type: integer
+          format: int32
+        numberOfRegisteredUsers:
+          type: integer
+          format: int32
+        isUserRegistered:
+          type: boolean
+    TutorialGroupFreePeriod:
+      type: object
+      required:
+        - id
+        - startDate
+        - endDate
+      properties:
+        id:
+          type: integer
+          format: int64
+        startDate:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
+        reason:
+          type: string
+    TutorialGroupFreePeriodRequest:
+      type: object
+      required:
+        - startDate
+        - endDate
+      properties:
+        startDate:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
+        reason:
+          type: string

--- a/src/test/resources/fixtures/tutorial-groups-openapi.yaml
+++ b/src/test/resources/fixtures/tutorial-groups-openapi.yaml
@@ -253,6 +253,25 @@ components:
           format: int32
         isUserRegistered:
           type: boolean
+    TutorialGroupConfiguration:
+      type: object
+      required:
+        - tutorialPeriodStartInclusive
+        - tutorialPeriodEndInclusive
+      properties:
+        id:
+          type: integer
+          format: int64
+        tutorialPeriodStartInclusive:
+          type: string
+          format: date
+        tutorialPeriodEndInclusive:
+          type: string
+          format: date
+        tutorialGroupFreePeriods:
+          type: array
+          items:
+            $ref: '#/components/schemas/TutorialGroupFreePeriod'
     TutorialGroupFreePeriod:
       type: object
       required:


### PR DESCRIPTION
## Summary

This is prep work for the E2E tracer for implementing the httpResource clients in Artemis.

- add a Tutorial Groups fixture test covering GET resource and mutation service generation
- fix path interpolation for generated `httpResource` URLs
- fix generated mutation calls for void responses and split model imports by resource/service usage

## Validation
- `./gradlew test`
- `./gradlew build`
- `./gradlew generateExample`
- `./gradlew publishToMavenLocal`