### PR TITLE
feat: classical HttpClient GET methods + generation fixes (1.1.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,18 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     
-    - name: Publish to GitHub Packages
-      run: ./gradlew publish
+    - name: Publish to Maven Central
+      # Uploads the signed artifacts to the Central Portal and (automaticRelease = true) releases them.
+      # Requires four repository secrets — see RELEASING.md:
+      #   MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD : a Central Portal user token
+      #   SIGNING_KEY (ASCII-armored GPG private key) / SIGNING_PASSWORD : the signing key + passphrase
+      run: ./gradlew publishToMavenCentral --no-configuration-cache
       env:
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ plugins {
 
 dependencies {
     // Add as a dependency to the openapi generator
-    openapiGenerator("de.tum.cit.aet:openapi-generator-angular21:1.0.0")
+    openapiGenerator("de.tum.cit.aet:openapi-generator-angular21:1.1.0")
 }
 
 openApiGenerate {
@@ -160,7 +160,7 @@ plugins {
 
 dependencies {
     // Add as a dependency to the openapi generator
-    openapiGenerator 'de.tum.cit.aet:openapi-generator-angular21:1.0.0'
+    openapiGenerator 'de.tum.cit.aet:openapi-generator-angular21:1.1.0'
 }
 
 openApiGenerate {
@@ -205,7 +205,7 @@ openApiGenerate {
         <dependency>
             <groupId>de.tum.cit.aet</groupId>
             <artifactId>openapi-generator-angular21</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -215,10 +215,10 @@ openApiGenerate {
 
 ```bash
 # Download the generator JAR
-wget https://github.com/ls1intum/openapi-generator-angular21/releases/download/v1.0.0/openapi-generator-angular21-1.0.0.jar
+wget https://github.com/ls1intum/openapi-generator-angular21/releases/download/v1.1.0/openapi-generator-angular21-1.1.0.jar
 
 # Generate code
-java -cp openapi-generator-angular21-1.0.0.jar:openapi-generator-cli-7.18.0.jar \
+java -cp openapi-generator-angular21-1.1.0.jar:openapi-generator-cli-7.18.0.jar \
     org.openapitools.codegen.OpenAPIGenerator generate \
     -g angular21 \
     -i openapi.yaml \
@@ -328,11 +328,15 @@ This generates Angular client code into `build/generated/example` using `example
 
 ## Publishing
 
-```bash
-# To GitHub Packages
-./gradlew publish
+The generator is published to **Maven Central**, so consumers resolve it from a plain `mavenCentral()`
+repository with no authentication. Releases are automated: pushing a `v*` tag runs the publish job in
+[`.github/workflows/build.yml`](.github/workflows/build.yml), which uploads the signed artifacts to the
+Central Portal. See **[RELEASING.md](RELEASING.md)** for the one-time account/secret setup and the full
+release procedure.
 
-# To Maven Local (for testing)
+```bash
+# Build the artifacts into your local Maven repository (no signing key required) — this is how
+# downstream projects (e.g. Artemis) build the generator from source to regenerate their client.
 ./gradlew publishToMavenLocal
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,86 @@
+# Releasing
+
+This generator is published to **Maven Central** (the Sonatype Central Portal). Consumers — Artemis and
+any other project — then resolve it from a plain `mavenCentral()` repository, with **no authentication**:
+
+```kotlin
+repositories { mavenCentral() }
+dependencies { /* openapiGenerator | classpath */ "de.tum.cit.aet:openapi-generator-angular21:1.1.0" }
+```
+
+Publishing is automated by [`.github/workflows/build.yml`](.github/workflows/build.yml): pushing a tag
+that starts with `v` (e.g. `v1.1.0`) runs the `publish` job, which uploads the GPG-signed artifacts to
+the Central Portal via the [`com.vanniktech.maven.publish`](https://vanniktech.github.io/gradle-maven-publish-plugin/)
+plugin and (because `automaticRelease = true`) releases the deployment once it validates.
+
+## One-time setup
+
+These steps are done **once** by a maintainer/org admin; afterwards every release is just a tag push.
+
+### 1. Claim the `de.tum.cit.aet` namespace on the Central Portal
+
+1. Sign in at <https://central.sonatype.com> (GitHub or email).
+2. Add the namespace `de.tum.cit.aet` and verify ownership of the `tum.de` domain by publishing the
+   **DNS `TXT` record** the portal shows you (a one-off verification token).
+   - This requires access to the `tum.de` DNS zone. If that is not available, the simplest alternative
+     is to switch the `group` to `io.github.ls1intum` (GitHub-verified, no DNS needed) — but that
+     changes the artifact coordinates everywhere, so the `tum.de` namespace is preferred.
+
+### 2. Generate a Central Portal user token
+
+In the Central Portal → *Account* → *Generate User Token*. This yields a username/password pair used
+for the upload (it is **not** your login password).
+
+### 3. Create a GPG signing key
+
+```bash
+gpg --gen-key                                   # create a key for the maintainer/CI identity
+gpg --list-secret-keys --keyid-format=long      # note the key id
+# Publish the public key so Central can verify signatures:
+gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
+# Export the private key in the ASCII-armored form the plugin expects:
+gpg --armor --export-secret-keys <KEY_ID>       # the whole block, including the BEGIN/END lines
+```
+
+### 4. Add four GitHub Actions repository secrets
+
+`Settings → Secrets and variables → Actions → New repository secret`:
+
+| Secret                   | Value                                                              |
+|--------------------------|-------------------------------------------------------------------|
+| `MAVEN_CENTRAL_USERNAME` | Central Portal user-token **username**                            |
+| `MAVEN_CENTRAL_PASSWORD` | Central Portal user-token **password**                            |
+| `SIGNING_KEY`            | the full ASCII-armored GPG **private** key from step 3            |
+| `SIGNING_PASSWORD`       | the passphrase for that key                                       |
+
+The workflow maps these onto the Gradle properties the plugin reads
+(`ORG_GRADLE_PROJECT_mavenCentralUsername`, `…Password`, `…signingInMemoryKey`, `…signingInMemoryKeyPassword`).
+
+## Cutting a release
+
+1. Bump `version` in [`build.gradle.kts`](build.gradle.kts) (and the version references in
+   [`README.md`](README.md)) to the new release version, e.g. `1.2.0`. Use a non-`SNAPSHOT` version.
+2. Merge to `main`.
+3. Tag and push:
+   ```bash
+   git tag v1.2.0
+   git push origin v1.2.0
+   ```
+4. The `publish` job signs and uploads to the Central Portal and creates a GitHub Release. The artifact
+   appears on Maven Central within ~15–30 minutes (search index can lag a few hours).
+
+## Releasing locally (fallback)
+
+If you ever need to publish without CI, provide the same four values as Gradle properties (e.g. in
+`~/.gradle/gradle.properties`: `mavenCentralUsername`, `mavenCentralPassword`, `signingInMemoryKey`,
+`signingInMemoryKeyPassword`) and run:
+
+```bash
+./gradlew publishToMavenCentral --no-configuration-cache
+```
+
+## Building without releasing
+
+`./gradlew publishToMavenLocal` installs the artifacts into your local `~/.m2` repository and **requires
+no signing key** (signing is gated on the key being present). This is the path downstream projects use to
+build the generator from source when they want to regenerate their client before a version is on Central.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,13 @@
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.plugins.signing.Sign
+
 plugins {
     java
     `java-library`
-    `maven-publish`
-    signing
+    // Publishes signed artifacts to the Maven Central (Sonatype) Portal. Replaces the manual
+    // maven-publish + signing setup: it wires the sources/javadoc jars, the POM, GPG signing, and the
+    // Central Portal upload. See RELEASING.md for the required credentials and the release procedure.
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 group = "de.tum.cit.aet"
@@ -12,8 +17,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
-    withJavadocJar()
-    withSourcesJar()
 }
 
 repositories {
@@ -63,48 +66,52 @@ tasks.withType<Jar> {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components["java"])
+mavenPublishing {
+    // Upload to the Maven Central Portal (central.sonatype.com) and release automatically once the
+    // staged deployment validates. Consumers then resolve the artifact from plain mavenCentral() with
+    // no authentication.
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+    // All artifacts must be GPG-signed for Maven Central. The signing key is provided via Gradle
+    // properties / environment variables in CI (see RELEASING.md); signing is skipped for
+    // publishToMavenLocal, so building from source needs no key.
+    signAllPublications()
 
-            pom {
-                name.set("OpenAPI Generator Angular 21")
-                description.set("Custom OpenAPI Generator for modern Angular 21 with httpResource and signals")
-                url.set("https://github.com/ls1intum/openapi-generator-angular21")
+    coordinates(group.toString(), "openapi-generator-angular21", version.toString())
 
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://opensource.org/licenses/MIT")
-                    }
-                }
+    pom {
+        name.set("OpenAPI Generator Angular 21")
+        description.set("Custom OpenAPI Generator for modern Angular 21 with httpResource and signals")
+        url.set("https://github.com/ls1intum/openapi-generator-angular21")
 
-                developers {
-                    developer {
-                        id.set("ls1intum")
-                        name.set("LS1 TUM")
-                        email.set("krusche@tum.de")
-                    }
-                }
-
-                scm {
-                    connection.set("scm:git:git://github.com/ls1intum/openapi-generator-angular21.git")
-                    developerConnection.set("scm:git:ssh://github.com/ls1intum/openapi-generator-angular21.git")
-                    url.set("https://github.com/ls1intum/openapi-generator-angular21")
-                }
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
             }
         }
-    }
 
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/ls1intum/openapi-generator-angular21")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+        developers {
+            developer {
+                id.set("ls1intum")
+                name.set("LS1 TUM")
+                email.set("krusche@tum.de")
             }
         }
+
+        scm {
+            connection.set("scm:git:git://github.com/ls1intum/openapi-generator-angular21.git")
+            developerConnection.set("scm:git:ssh://github.com/ls1intum/openapi-generator-angular21.git")
+            url.set("https://github.com/ls1intum/openapi-generator-angular21")
+        }
     }
+}
+
+// Only sign when a signing key is configured — i.e. during a Central Portal release in CI, where the
+// SIGNING_KEY secret is provided as ORG_GRADLE_PROJECT_signingInMemoryKey. Building from source via
+// `./gradlew publishToMavenLocal` (the fallback consumers use to regenerate the client) needs no GPG
+// key: the local repository does not require signatures. The flag is read at configuration time so it
+// stays compatible with the configuration cache.
+val signingKeyPresent = providers.gradleProperty("signingInMemoryKey").isPresent
+tasks.withType<Sign>().configureEach {
+    onlyIf { signingKeyPresent }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "de.tum.cit.aet"
-version = "1.0.0"
+version = "1.1.0"
 
 java {
     toolchain {
@@ -23,7 +23,7 @@ repositories {
 val openapiGeneratorCli by configurations.creating
 
 dependencies {
-    val openapiGeneratorVersion = "7.18.0"
+    val openapiGeneratorVersion = "7.21.0"
 
     // OpenAPI Generator core dependency
     implementation("org.openapitools:openapi-generator:$openapiGeneratorVersion")

--- a/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
+++ b/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
@@ -171,7 +171,10 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
         for (Map.Entry<String, TagUsage> entry : usageByTag.entrySet()) {
             String apiFilename = toApiFilename(entry.getKey());
             TagUsage usage = entry.getValue();
-            if (!usage.hasMutation) {
+            // In httpResource mode a GET-only tag has no mutations, so its API service file would be
+            // empty and is suppressed. In classical mode the GETs are rendered into the API service,
+            // so the file must be kept even when the tag has no mutations.
+            if (useHttpResource && !usage.hasMutation) {
                 openapiGeneratorIgnoreList.add("api/" + apiFilename + "-api.ts");
             }
             if (useHttpResource && separateResources && !usage.hasGet) {
@@ -265,6 +268,29 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         OperationsMap result = super.postProcessOperationsWithModels(objs, allModels);
 
+        // Each model must be imported from its own file. The default `imports` entries do not carry a
+        // per-entry filename, so `{{classFilename}}` in the api templates falls through to the
+        // enclosing API's filename and every model is (wrongly) imported from the same path. Compute
+        // the correct model filename per import here.
+        Object importsObj = result.get("imports");
+        if (importsObj instanceof List<?> importsList) {
+            for (Object item : importsList) {
+                if (item instanceof Map<?, ?> rawImport) {
+                    Object className = rawImport.get("classname");
+                    if (className == null) {
+                        className = rawImport.get("import");
+                    }
+                    if (className != null) {
+                        String simpleName = className.toString();
+                        simpleName = simpleName.substring(simpleName.lastIndexOf('.') + 1);
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> mutableImport = (Map<String, Object>) rawImport;
+                        mutableImport.put("classFilename", toModelFilename(simpleName));
+                    }
+                }
+            }
+        }
+
         OperationMap operations = result.getOperations();
         List<CodegenOperation> ops = operations.getOperation();
 
@@ -276,7 +302,8 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
             // Add custom vendor extensions
             op.vendorExtensions.put("x-use-inject", useInjectFunction);
 
-            if ("GET".equalsIgnoreCase(op.httpMethod)) {
+            boolean isGet = "GET".equalsIgnoreCase(op.httpMethod);
+            if (isGet) {
                 op.vendorExtensions.put("x-is-get", true);
                 op.vendorExtensions.put("x-use-http-resource", useHttpResource);
                 getOperations.add(op);
@@ -285,6 +312,15 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
                 op.vendorExtensions.put("x-is-mutation", true);
                 mutationOperations.add(op);
             }
+
+            // A GET is rendered in the (classical) API service unless it is delegated to a
+            // signal-based httpResource. All non-GET operations always live in the API service.
+            op.vendorExtensions.put("x-render-in-service", !isGet || !useHttpResource);
+
+            // HttpClient.post/put/patch require a body argument (pass null when the operation has
+            // none); get/delete take only the URL. Independent of query params (those go in the URL).
+            String method = op.httpMethod == null ? "" : op.httpMethod.toUpperCase(Locale.ROOT);
+            op.vendorExtensions.put("x-needs-body-arg", method.equals("POST") || method.equals("PUT") || method.equals("PATCH"));
 
             // Process path parameters
             processPathParameters(op);
@@ -386,7 +422,10 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
             } else if (useSignalValue && signalValueByParamName.containsKey(valueVar)) {
                 replacementVar = signalValueByParamName.get(valueVar);
             }
-            String replacement = "{" + replacementVar + "}";
+            // Emit a template-literal interpolation (${...}); the surrounding template wraps the path
+            // in a `${this.basePath}...` template string. Without the leading $, non-numeric path
+            // params were rendered as literal "{paramPath}" text (and their encode const went unused).
+            String replacement = "${" + replacementVar + "}";
             matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(buffer);
@@ -400,8 +439,12 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
                 if (templateVarByParamName.containsKey(param.paramName)) {
                     valueVar = templateVarByParamName.get(param.paramName);
                 }
-                String placeholder = "{" + param.baseName + "}";
-                path = path.replace(placeholder, "${" + valueVar + "}");
+                // Fallback for any raw "{baseName}" placeholders not already turned into a
+                // template-literal interpolation by the encodeParam pass above. The negative
+                // lookbehind avoids matching the "{baseName}" inside an already-produced
+                // "${baseName}" (which would yield a doubled "$${baseName}").
+                String placeholder = "(?<!\\$)" + Pattern.quote("{" + param.baseName + "}");
+                path = path.replaceAll(placeholder, Matcher.quoteReplacement("${" + valueVar + "}"));
             }
         }
 

--- a/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
+++ b/src/main/java/de/tum/cit/aet/openapi/Angular21Generator.java
@@ -313,6 +313,19 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
                 mutationOperations.add(op);
             }
 
+            // Non-JSON GET responses need an explicit Angular HttpClient responseType. Without it the
+            // client defaults to responseType 'json' and tries to JSON.parse text/binary payloads
+            // (e.g. iCalendar files, CSV exports, plain-text tokens), which throws at runtime. A binary
+            // (Blob) return becomes responseType 'blob'; a string return whose produced media types are
+            // all text/* becomes responseType 'text'. JSON-string endpoints keep the default parser.
+            if (isGet) {
+                if ("Blob".equals(op.returnType)) {
+                    op.vendorExtensions.put("x-response-type", "blob");
+                } else if ("string".equals(op.returnType) && producesTextOnly(op)) {
+                    op.vendorExtensions.put("x-response-type", "text");
+                }
+            }
+
             // A GET is rendered in the (classical) API service unless it is delegated to a
             // signal-based httpResource. All non-GET operations always live in the API service.
             op.vendorExtensions.put("x-render-in-service", !isGet || !useHttpResource);
@@ -463,6 +476,24 @@ public class Angular21Generator extends TypeScriptAngularClientCodegen {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Whether the operation only produces text media types (e.g. text/plain, text/calendar, text/csv).
+     * Used to emit responseType: 'text' for string-returning GETs; JSON-string endpoints (which produce
+     * application/json) return false and keep the default JSON parser.
+     */
+    private boolean producesTextOnly(CodegenOperation op) {
+        if (op.produces == null || op.produces.isEmpty()) {
+            return false;
+        }
+        for (Map<String, String> mediaType : op.produces) {
+            String type = mediaType.get("mediaType");
+            if (type == null || !type.toLowerCase(Locale.ROOT).startsWith("text/")) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/resources/angular21/api-service.mustache
+++ b/src/main/resources/angular21/api-service.mustache
@@ -17,7 +17,7 @@ export class {{classname}} {
 
 {{#operations}}
 {{#operation}}
-{{^vendorExtensions.x-is-get}}
+{{#vendorExtensions.x-render-in-service}}
     /**
      * {{summary}}
      * {{notes}}
@@ -61,26 +61,26 @@ export class {{classname}} {
 {{/isArray}}
         }
 {{/formParams}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url, formData);
+        return this.http.{{httpMethod}}<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url, formData);
 {{/hasFormParams}}
 {{^hasFormParams}}
 {{#bodyParam}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url, {{paramName}});
+        return this.http.{{httpMethod}}<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url, {{paramName}});
 {{/bodyParam}}
 {{^bodyParam}}
-{{#hasQueryParams}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url);
-{{/hasQueryParams}}
-{{^hasQueryParams}}
-{{#vendorExtensions.x-is-mutation}}
-        return this.http.{{httpMethod}}{{#returnType}}<{{{.}}}>{{/returnType}}(url{{#isBodyAllowed}}, null{{/isBodyAllowed}});
-{{/vendorExtensions.x-is-mutation}}
-{{/hasQueryParams}}
+{{! POST/PUT/PATCH require a body argument even when the operation has none (pass null). }}
+{{! GET/DELETE take only the URL. Query parameters live in the URL, not the body. }}
+{{#vendorExtensions.x-needs-body-arg}}
+        return this.http.{{httpMethod}}<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url, null);
+{{/vendorExtensions.x-needs-body-arg}}
+{{^vendorExtensions.x-needs-body-arg}}
+        return this.http.{{httpMethod}}<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url);
+{{/vendorExtensions.x-needs-body-arg}}
 {{/bodyParam}}
 {{/hasFormParams}}
     }
 
-{{/vendorExtensions.x-is-get}}
+{{/vendorExtensions.x-render-in-service}}
 {{/operation}}
 {{/operations}}
 }

--- a/src/main/resources/angular21/api-service.mustache
+++ b/src/main/resources/angular21/api-service.mustache
@@ -74,7 +74,15 @@ export class {{classname}} {
         return this.http.{{httpMethod}}<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url, null);
 {{/vendorExtensions.x-needs-body-arg}}
 {{^vendorExtensions.x-needs-body-arg}}
+{{! Non-JSON GETs (iCal, CSV, plain text) need an explicit responseType so HttpClient does not }}
+{{! JSON-parse the body. The text/blob overloads return Observable<string>/Observable<Blob>, so the }}
+{{! method's declared return type is preserved without the generic type argument. }}
+{{#vendorExtensions.x-response-type}}
+        return this.http.{{httpMethod}}(url, { responseType: '{{vendorExtensions.x-response-type}}' });
+{{/vendorExtensions.x-response-type}}
+{{^vendorExtensions.x-response-type}}
         return this.http.{{httpMethod}}<{{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(url);
+{{/vendorExtensions.x-response-type}}
 {{/vendorExtensions.x-needs-body-arg}}
 {{/bodyParam}}
 {{/hasFormParams}}

--- a/src/main/resources/angular21/model.mustache
+++ b/src/main/resources/angular21/model.mustache
@@ -2,7 +2,7 @@
 {{#models}}
 {{#model}}
 {{#tsImports}}
-import type { {{classname}} } from '{{filename}}';
+import type { {{classname}} } from './{{filename}}';
 {{/tsImports}}
 
 {{#description}}
@@ -22,7 +22,7 @@ export interface {{classname}}{{#parent}} extends {{.}}{{/parent}} {
 {{#description}}
     /** {{{.}}} */
 {{/description}}
-{{#vendorExtensions.x-is-readonly}}    readonly {{/vendorExtensions.x-is-readonly}}{{^vendorExtensions.x-is-readonly}}    {{/vendorExtensions.x-is-readonly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{classname}}{{enumName}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
+{{#vendorExtensions.x-is-readonly}}    readonly {{/vendorExtensions.x-is-readonly}}{{^vendorExtensions.x-is-readonly}}    {{/vendorExtensions.x-is-readonly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{#isArray}}Array<{{/isArray}}{{classname}}{{enumName}}{{#isArray}}>{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
 {{/vars}}
 }
 {{#hasEnums}}


### PR DESCRIPTION
## Summary
Makes the classical (non-`httpResource`) generation mode usable and fixes several code-generation bugs discovered while adopting this generator for the Artemis OpenAPI client. Switches publishing to **Maven Central** and bumps the version to **1.1.0**.

## Changes
- **Classical `HttpClient.get()` GET methods** (`useHttpResource=false`): GET operations are now emitted as classical `Observable` methods in the API service. Previously every operation in `api-service.mustache` was wrapped in `{{^vendorExtensions.x-is-get}}`, so GETs were only ever produced via the `httpResource` resource template — disabling `useHttpResource` silently dropped **all** GET endpoints. GET-only tags now also keep their `-api.ts` file in classical mode.
- **Relative model imports**: model-to-model imports are now `'./other-model'` instead of the bare `'other-model'`, which did not resolve.
- **`Observable<void>`**: operations always emit an explicit response type parameter, so void endpoints return `Observable<void>` instead of `Observable<Object>`.
- **Mutation body argument**: POST/PUT/PATCH always pass a body argument (`HttpClient` requires it; a missing body produced a TS *"Expected 2–3 arguments"* error).
- **Path-parameter interpolation**: non-numeric path params are interpolated as `${param}` instead of the literal text `{param}`; numeric params no longer get a doubled `$`.
- **Array-of-enum properties**: wrapped in `Array<…>` instead of a single enum type.
- Build against **openapi-generator 7.21.0** (aligned with the `org.openapi.generator` Gradle plugin version used downstream in Artemis).
- **Publish to Maven Central**: replaces GitHub Packages publishing (which requires authentication even to *download*) with the Sonatype Central Portal via the `com.vanniktech.maven.publish` plugin, so consumers resolve the generator from a plain `mavenCentral()` with no auth. Artifacts are GPG-signed, gated on a key being present so `publishToMavenLocal` still works key-free. Adds `RELEASING.md`.

## Context
These fixes are required for the Artemis client to compile and run after switching its OpenAPI client to this generator (Artemis PR ls1intum/Artemis#13038). Configured there with `useHttpResource=false, useInjectFunction=true, separateResources=false, readonlyModels=false`.

## Releasing 1.1.0 (maintainers)
Publishing now targets **Maven Central** (auth-free for consumers). One-time setup — see `RELEASING.md`:
1. Claim the `de.tum.cit.aet` namespace on central.sonatype.com (verify `tum.de` via a DNS TXT record).
2. Generate a Central Portal user token and a GPG signing key (publish the public key to a keyserver).
3. Add four repo secrets: `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY` (ASCII-armored private key), `SIGNING_PASSWORD`.

Then release by pushing a tag: `git tag v1.1.0 && git push origin v1.1.0` — the workflow signs and uploads to the Central Portal and creates a GitHub Release.